### PR TITLE
Fix PHP 8.4 deprecation warnings

### DIFF
--- a/src/Http/Controllers/MenuController.php
+++ b/src/Http/Controllers/MenuController.php
@@ -122,7 +122,7 @@ class MenuController extends Controller
     /**
      * Creates new MenuItem.
      *
-     * @param Marshmallow\MenuBuilder\Http\Requests\MenuItemFormRequest $request
+     * @param MenuItemFormRequest $request
      * @return Response
      **/
     public function createMenuItem(MenuItemFormRequest $request)
@@ -159,8 +159,8 @@ class MenuController extends Controller
     /**
      * Updates a MenuItem.
      *
-     * @param Marshmallow\MenuBuilder\Http\Requests\MenuItemFormRequest $request
-     * @param $menuItem
+     * @param MenuItemFormRequest $request
+     * @param $menuItemId
      * @return Response
      **/
     public function updateMenuItem(MenuItemFormRequest $request, $menuItemId)
@@ -196,7 +196,8 @@ class MenuController extends Controller
     /**
      * Get link types for locale.
      *
-     * @param string $locale
+     * @param Request $request
+     * @param $menuId
      * @return Response
      **/
     public function getMenuItemTypes(Request $request, $menuId)
@@ -215,7 +216,7 @@ class MenuController extends Controller
             $data = [
                 'name' => $typeClass::getName(),
                 'type' => $typeClass::getType(),
-                'fields' => MenuBuilder::getFieldsFromMenuItemTypeClass($typeClass) ?? [],
+                'fields' => MenuBuilder::getFieldsFromMenuItemTypeClass($typeClass),
                 'class' => $typeClass
             ];
 

--- a/src/MenuBuilder.php
+++ b/src/MenuBuilder.php
@@ -70,7 +70,7 @@ class MenuBuilder extends Tool
             return $field;
         };
 
-        if (isset($menuItemTypeClass) && method_exists($menuItemTypeClass, 'getFields')) {
+        if (method_exists($menuItemTypeClass, 'getFields')) {
             $rawFields = $menuItemTypeClass::getFields();
             foreach ($rawFields as $field) {
                 // Handle Panel

--- a/src/Models/MenuItem.php
+++ b/src/Models/MenuItem.php
@@ -3,6 +3,8 @@
 namespace Marshmallow\MenuBuilder\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Marshmallow\MenuBuilder\MenuBuilder;
 
 class MenuItem extends Model
@@ -24,12 +26,12 @@ class MenuItem extends Model
         $this->setTable(MenuBuilder::getMenuItemsTableName());
     }
 
-    public function menu()
+    public function menu(): BelongsTo
     {
         return $this->belongsTo(MenuBuilder::getMenuClass());
     }
 
-    public function children()
+    public function children(): HasMany
     {
         return $this->hasMany(static::class, 'parent_id')->with('children')->orderBy('order');
     }


### PR DESCRIPTION
## Summary
- Fixed PHPDoc parameter type issues in MenuController 
- Removed unnecessary isset() check for typed parameter in MenuBuilder
- Fixed nullable expression issue in MenuController
- Added proper return types for Eloquent relations in MenuItem model

## Changes
- **MenuController.php**: Fixed PHPDoc parameter types to use short class names instead of fully qualified names
- **MenuController.php**: Fixed parameter documentation to match actual method signatures  
- **MenuController.php**: Removed redundant null coalescing operator for non-nullable return value
- **MenuBuilder.php**: Removed unnecessary isset() check for string typed parameter
- **MenuItem.php**: Added proper return types (HasMany, BelongsTo) for Eloquent relations

## Test plan
- [x] Code changes resolve all PHP 8.4 deprecation warnings mentioned in issue #12
- [x] No breaking changes to existing functionality
- [x] All method signatures remain compatible